### PR TITLE
Fixed API compatibility (supposedly API has changed over time)

### DIFF
--- a/lib/openkvk.rb
+++ b/lib/openkvk.rb
@@ -3,44 +3,45 @@ require File.expand_path('../openkvk/api', __FILE__)
 
 module OpenKVK
   extend Configuration
-    
+
   class << self
-    
+
     def search(keywords)
-      numbers = API.search(keywords)
+      results = API.search(keywords)
+      numbers = results.collect{|result| result.kvk}
       numbers.size > 0 ? API.query("SELECT * FROM kvk WHERE kvk IN (#{numbers.join(", ")})") : []
     end
-    
+
     def find(options={})
       if options.is_a?(String)
-        options = {:conditions => ["bedrijfsnaam LIKE '%#{options}%'", "bedrijfsnaam LIKE '%#{options.to_s.upcase}%'", "bedrijfsnaam LIKE '%#{capitalize_and_format_each_word(options)}%'"], :match_condition => :any}
+        options = {:conditions => ["bedrijfsnaam ILIKE '%#{options}%'"], :match_condition => :any}
       end
-      options = {:limit => 1000, :select => ["*"], :count => :all, :match_condition => :all}.merge(options)
-      
+      options = {:limit => 99, :select => ["*"], :count => :all, :match_condition => :all}.merge(options)
+
       options[:limit] = 1 if options[:count] == :first
       result = API.query("SELECT #{options[:select].join(", ")} FROM kvk WHERE #{options[:conditions].join(options[:match_condition] == :any ? " OR " : " AND ")} LIMIT #{options[:limit]}")
       return result.first if options[:count] == :first
       result
     end
-    
-    def find_by_bedrijfsnaam(name, options={})
-      # bedrijfsnaam is always a string, so we want to search for different formats of the string
-      options = {:conditions => ["bedrijfsnaam LIKE '%#{name}%'", "bedrijfsnaam LIKE '%#{name.to_s.upcase}%'", "bedrijfsnaam LIKE '%#{capitalize_and_format_each_word(name)}%'"], :match_condition => :any}.merge(options)
+
+    def find_by_kvk(kvk, options={})
+      #kvk is not a string, so no like query...
+      options = {:conditions => ["kvks = #{kvk}", "kvk = #{kvk}"], :match_condition => :any}.merge(options)
       find(options)
     end
-    
-    %w{kvk kvks adres postcode plaats type website}.each do |field|      
-      define_method("find_by_#{field}") do |value, options|
+
+    %w{adres bedrijfsnaam postcode plaats type website}.each do |field|
+      define_method("find_by_#{field}") do |value, options={}|
         options = {:conditions => ["#{field} ILIKE '%#{value}%'"]}.merge(options || {})
         find(options)
       end
     end
 
     private
-    
+
     def capitalize_and_format_each_word(name)
       # capitalize each word
-      name.gsub!(/\b('?[a-z])/) do |word| 
+      name.gsub!(/\b('?[a-z])/) do |word|
         $1.capitalize
       end
 
@@ -50,7 +51,7 @@ module OpenKVK
       end
       name
     end
-    
+
   end
-  
+
 end

--- a/spec/openkvk/api_spec.rb
+++ b/spec/openkvk/api_spec.rb
@@ -3,41 +3,41 @@ require 'net/http'
 require File.expand_path('../../spec_helper', __FILE__)
 
 describe OpenKVK do
-  
+
   describe ".get" do
     it "should return an array with records" do
       response = Hashie::Mash.new(:body => '[{"RESULT":{"TYPES":["bigint","varchar","int","int","varchar","varchar","varchar","varchar","varchar"],"HEADER":["kvk","bedrijfsnaam","kvks","sub","adres","postcode","plaats","type","website"],"ROWS":[["342838240000","Zilverline Beheer B.V.","34283824","0","Finsenstraat 56","1098RJ","Amsterdam","Hoofdvestiging",null],["343774520000","Zilverline B.V.","34377452","0","Molukkenstraat 200 E4","1098TW","Amsterdam","Hoofdvestiging",null]]}}]')
       Net::HTTP.stubs(:get_response).returns(response)
-      
-      OpenKVK::API.query("SELECT * FROM kvk WHERE bedrijfsnaam LIKE '%Zilverline%' LIMIT 1000").size.should == 2
+
+      OpenKVK::API.query("SELECT * FROM kvk WHERE bedrijfsnaam LIKE '%Zilverline%' LIMIT 99").size.should == 2
     end
-    
+
     it "should follow a redirect" do
       response = Hashie::Mash.new(:Location => "new location", :body => '[{"RESULT":{"TYPES":["bigint","varchar","int","int","varchar","varchar","varchar","varchar","varchar"],"HEADER":["kvk","bedrijfsnaam","kvks","sub","adres","postcode","plaats","type","website"],"ROWS":[["342838240000","Zilverline Beheer B.V.","34283824","0","Finsenstraat 56","1098RJ","Amsterdam","Hoofdvestiging",null],["343774520000","Zilverline B.V.","34377452","0","Molukkenstraat 200 E4","1098TW","Amsterdam","Hoofdvestiging",null]]}}]')
 
       response.stubs(:kind_of?).returns(Net::HTTPRedirection)
       Net::HTTP.stubs(:get_response).returns(response)
-      
-      OpenKVK::API.query("SELECT * FROM kvk WHERE bedrijfsnaam LIKE '%Zilverline%' LIMIT 1000").size.should == 2
+
+      OpenKVK::API.query("SELECT * FROM kvk WHERE bedrijfsnaam LIKE '%Zilverline%' LIMIT 99").size.should == 2
     end
-    
+
     it "should raise an exception when something goes wrong" do
       Net::HTTP.stubs(:get_response).raises(Exception.new("test exception"))
       lambda {
-        OpenKVK::API.query("SELECT * FROM kvk WHERE bedrijfsnaam LIKE '%Zilverline%' LIMIT 1000")
+        OpenKVK::API.query("SELECT * FROM kvk WHERE bedrijfsnaam LIKE '%Zilverline%' LIMIT 99")
       }.should raise_error OpenKVK::InvalidResponseException
     end
-    
+
     it "should raise an exception when an blank result is returned by the host" do
       response = stub(:body => "")
       response.stubs(:kind_of?).returns(false)
       Net::HTTP.stubs(:get_response).returns(response)
-      
+
       lambda {
         OpenKVK::API.search("zilverline")
       }.should raise_error OpenKVK::InvalidResponseException
     end
-    
+
   end
-  
+
 end

--- a/spec/openkvk_spec.rb
+++ b/spec/openkvk_spec.rb
@@ -1,7 +1,7 @@
 require File.expand_path('../spec_helper', __FILE__)
 
 describe OpenKVK do
-  
+
   describe ".find" do
     it "should find a company" do
       expect_query("SELECT * FROM kvk WHERE bedrijfsnaam LIKE '%Zilverline%' LIMIT 1", '[{"RESULT":{"TYPES":["bigint","varchar","int","int","varchar","varchar","varchar","varchar","varchar"],"HEADER":["kvk","bedrijfsnaam","kvks","sub","adres","postcode","plaats","type","website"],"ROWS":[["343774520000","Zilverline B.V.","34377452","0","Molukkenstraat 200 E4","1098TW","Amsterdam","Hoofdvestiging",null]]}}]')
@@ -15,34 +15,34 @@ describe OpenKVK do
       company.type.should == "Hoofdvestiging"
       company.website.should be nil
     end
-    
+
     it "should find multiple companies" do
-      expect_query("SELECT * FROM kvk WHERE bedrijfsnaam LIKE '%Zilverline%' OR bedrijfsnaam LIKE '%ZILVERLINE%' OR bedrijfsnaam LIKE '%Zilverline%' LIMIT 1000", '[{"RESULT":{"TYPES":["bigint","varchar","int","int","varchar","varchar","varchar","varchar","varchar"],"HEADER":["kvk","bedrijfsnaam","kvks","sub","adres","postcode","plaats","type","website"],"ROWS":[["342838240000","Zilverline Beheer B.V.","34283824","0","Finsenstraat 56","1098RJ","Amsterdam","Hoofdvestiging",null],["343774520000","Zilverline B.V.","34377452","0","Molukkenstraat 200 E4","1098TW","Amsterdam","Hoofdvestiging",null]]}}]')
-      
+      expect_query("SELECT * FROM kvk WHERE bedrijfsnaam ILIKE '%Zilverline%' LIMIT 99", '[{"RESULT":{"TYPES":["bigint","varchar","int","int","varchar","varchar","varchar","varchar","varchar"],"HEADER":["kvk","bedrijfsnaam","kvks","sub","adres","postcode","plaats","type","website"],"ROWS":[["342838240000","Zilverline Beheer B.V.","34283824","0","Finsenstraat 56","1098RJ","Amsterdam","Hoofdvestiging",null],["343774520000","Zilverline B.V.","34377452","0","Molukkenstraat 200 E4","1098TW","Amsterdam","Hoofdvestiging",null]]}}]')
+
       companies = OpenKVK.find("Zilverline")
       companies.size.should == 2
-      
+
       company = companies.last
       company.bedrijfsnaam.should == "Zilverline B.V."
     end
-    
+
     it "should only return selected fields" do
       expect_query("SELECT bedrijfsnaam FROM kvk WHERE bedrijfsnaam LIKE '%Zilverline%' LIMIT 1", '[{"RESULT":{"TYPES":["varchar"],"HEADER":["bedrijfsnaam"],"ROWS":[["Zilverline B.V."]]}}]')
-      
+
       company = OpenKVK.find(:conditions => ["bedrijfsnaam LIKE '%Zilverline%'"], :count => :first, :select => [:bedrijfsnaam])
-      
+
       company.bedrijfsnaam.should == "Zilverline B.V."
       company.keys.should == %w{bedrijfsnaam}
-      
+
       expect_query("SELECT bedrijfsnaam, kvk FROM kvk WHERE bedrijfsnaam LIKE '%Zilverline%' LIMIT 1", '[{"RESULT":{"TYPES":["varchar","bigint"],"HEADER":["bedrijfsnaam","kvk"],"ROWS":[["Zilverline B.V.","343774520000"]]}}]')
-      
+
       company = OpenKVK.find(:conditions => ["bedrijfsnaam LIKE '%Zilverline%'"], :count => :first, :select => [:bedrijfsnaam, :kvk])
-      
+
       company.bedrijfsnaam.should == "Zilverline B.V."
       company.kvk.should == "343774520000"
       company.keys.should == %w{bedrijfsnaam kvk}
     end
-    
+
     it "should find a company with multiple conditions" do
       expect_query("SELECT * FROM kvk WHERE bedrijfsnaam LIKE '%Zilverline%' AND kvk = '343774520000' LIMIT 1", '[{"RESULT":{"TYPES":["bigint","varchar","int","int","varchar","varchar","varchar","varchar","varchar"],"HEADER":["kvk","bedrijfsnaam","kvks","sub","adres","postcode","plaats","type","website"],"ROWS":[["343774520000","Zilverline B.V.","34377452","0","Molukkenstraat 200 E4","1098TW","Amsterdam","Hoofdvestiging",null]]}}]')
 
@@ -50,7 +50,7 @@ describe OpenKVK do
       company.bedrijfsnaam.should == "Zilverline B.V."
       company.kvk.should == "343774520000"
     end
-    
+
     it "should find a company with multiple conditions" do
       expect_query("SELECT * FROM kvk WHERE bedrijfsnaam LIKE '%FooBar%' OR kvk = '343774520000' LIMIT 1", '[{"RESULT":{"TYPES":["bigint","varchar","int","int","varchar","varchar","varchar","varchar","varchar"],"HEADER":["kvk","bedrijfsnaam","kvks","sub","adres","postcode","plaats","type","website"],"ROWS":[["343774520000","Zilverline B.V.","34377452","0","Molukkenstraat 200 E4","1098TW","Amsterdam","Hoofdvestiging",null]]}}]')
 
@@ -62,8 +62,8 @@ describe OpenKVK do
 
   describe ".search" do
     it "should search for a company with full text search" do
-      expect_search("ZiLvErLiNe", '[{"RESULT":[342838240000,343774520000]}]')
-      expect_query("SELECT * FROM kvk WHERE kvk IN (342838240000, 343774520000)", '[{"RESULT":{"TYPES":["bigint","varchar","int","int","varchar","varchar","varchar","varchar","varchar","varchar","bigint","varchar","decimal","decimal","date"],"HEADER":["kvk","bedrijfsnaam","kvks","sub","adres","postcode","plaats","type","status","website","vestiging","rechtsvorm","lat_rad","lon_rad","anbi"],"ROWS":[["343774520000","Zilverline B.V.","34377452",null,"Science Park 400","1098XH","Amsterdam","Hoofdvestiging",null,null,"19993846",null,"0.913791014","0.086494384",null],["342838240000","Zilverline Beheer B.V.","34283824",null,"Prins Hendriklaan 9","1404AR","Bussum","Hoofdvestiging",null,null,"5062055",null,"0.912472656","0.090085531",null]]}}]')
+      expect_search("ZiLvErLiNe", '[{"rechtspersoon":"Zilverline Beheer B.V.","vestigingsnummer":"000005062055","adres":"Prins Hendriklaan 9","kvk":"342838240000","handelsnamen":{"bestaand":["Zilverline Beheer B.V."]},"postcode":"1404AR","type":"Hoofdvestiging","kvks":"34283824","woonplaats":"Bussum"},{"rechtspersoon":"Zilverline B.V.","vestigingsnummer":"000019993846","adres":"Science Park 400","kvk":"343774520000","handelsnamen":{"bestaand":["Zilverline B.V.","Freemle"]},"postcode":"1098XH","type":"Hoofdvestiging","kvks":"34377452","woonplaats":"Amsterdam"},{"rechtspersoon":"Zilverline Beheer B.V.","type":"Rechtspersoon","kvk":"34283824","kvks":"34283824"},{"rechtspersoon":"Zilverline B.V.","type":"Rechtspersoon","kvk":"34377452","kvks":"34377452"}]')
+      expect_query("SELECT * FROM kvk WHERE kvk IN (342838240000, 343774520000, 34283824, 34377452)", '[{"RESULT":{"TYPES":["bigint","varchar","int","int","varchar","varchar","varchar","varchar","varchar","varchar","bigint","varchar","decimal","decimal","date"],"HEADER":["kvk","bedrijfsnaam","kvks","sub","adres","postcode","plaats","type","status","website","vestiging","rechtsvorm","lat_rad","lon_rad","anbi"],"ROWS":[["343774520000","Zilverline B.V.","34377452",null,"Science Park 400","1098XH","Amsterdam","Hoofdvestiging",null,null,"19993846",null,"0.913791014","0.086494384",null],["342838240000","Zilverline Beheer B.V.","34283824",null,"Prins Hendriklaan 9","1404AR","Bussum","Hoofdvestiging",null,null,"5062055",null,"0.912472656","0.090085531",null]]}}]')
 
       companies = OpenKVK.search("ZiLvErLiNe")
       companies.size.should == 2
@@ -80,35 +80,35 @@ describe OpenKVK do
 
   describe ".find_by_bedrijfsnaam" do
     it "should find a company" do
-      expect_query("SELECT * FROM kvk WHERE bedrijfsnaam LIKE '%Zilverline B.V.%' OR bedrijfsnaam LIKE '%ZILVERLINE B.V.%' OR bedrijfsnaam LIKE '%Zilverline B.V.%' LIMIT 1", '[{"RESULT":{"TYPES":["bigint","varchar","int","int","varchar","varchar","varchar","varchar","varchar"],"HEADER":["kvk","bedrijfsnaam","kvks","sub","adres","postcode","plaats","type","website"],"ROWS":[["343774520000","Zilverline B.V.","34377452","0","Molukkenstraat 200 E4","1098TW","Amsterdam","Hoofdvestiging",null]]}}]')
-    
+      expect_query("SELECT * FROM kvk WHERE bedrijfsnaam ILIKE '%Zilverline B.V.%' LIMIT 1", '[{"RESULT":{"TYPES":["bigint","varchar","int","int","varchar","varchar","varchar","varchar","varchar"],"HEADER":["kvk","bedrijfsnaam","kvks","sub","adres","postcode","plaats","type","website"],"ROWS":[["343774520000","Zilverline B.V.","34377452","0","Molukkenstraat 200 E4","1098TW","Amsterdam","Hoofdvestiging",null]]}}]')
+
       OpenKVK.find_by_bedrijfsnaam("Zilverline B.V.", :count => :first).bedrijfsnaam.should == "Zilverline B.V."
     end
   end
-  
+
   describe ".find_by_bedrijfsnaam" do
     it "should find a company even without BV or NV specified" do
-      expect_query("SELECT * FROM kvk WHERE bedrijfsnaam LIKE '%Zilverline%' OR bedrijfsnaam LIKE '%ZILVERLINE%' OR bedrijfsnaam LIKE '%Zilverline%' LIMIT 1", '[{"RESULT":{"TYPES":["bigint","varchar","int","int","varchar","varchar","varchar","varchar","varchar"],"HEADER":["kvk","bedrijfsnaam","kvks","sub","adres","postcode","plaats","type","website"],"ROWS":[["343774520000","Zilverline B.V.","34377452","0","Molukkenstraat 200 E4","1098TW","Amsterdam","Hoofdvestiging",null]]}}]')
-    
+      expect_query("SELECT * FROM kvk WHERE bedrijfsnaam ILIKE '%Zilverline%' LIMIT 1", '[{"RESULT":{"TYPES":["bigint","varchar","int","int","varchar","varchar","varchar","varchar","varchar"],"HEADER":["kvk","bedrijfsnaam","kvks","sub","adres","postcode","plaats","type","website"],"ROWS":[["343774520000","Zilverline B.V.","34377452","0","Molukkenstraat 200 E4","1098TW","Amsterdam","Hoofdvestiging",null]]}}]')
+
       OpenKVK.find_by_bedrijfsnaam("Zilverline", :count => :first).bedrijfsnaam.should == "Zilverline B.V."
     end
   end
-  
+
   describe ".find_by_kvk" do
     it "should find a company" do
-      expect_query("SELECT * FROM kvk WHERE kvk ILIKE '%343774520000%' LIMIT 1", '[{"RESULT":{"TYPES":["bigint","varchar","int","int","varchar","varchar","varchar","varchar","varchar"],"HEADER":["kvk","bedrijfsnaam","kvks","sub","adres","postcode","plaats","type","website"],"ROWS":[["343774520000","Zilverline B.V.","34377452","0","Molukkenstraat 200 E4","1098TW","Amsterdam","Hoofdvestiging",null]]}}]')
-    
+      expect_query('SELECT * FROM kvk WHERE kvks = 343774520000 OR kvk = 343774520000 LIMIT 1', '[{"RESULT":{"TYPES":["bigint","varchar","int","int","varchar","varchar","varchar","varchar","varchar"],"HEADER":["kvk","bedrijfsnaam","kvks","sub","adres","postcode","plaats","type","website"],"ROWS":[["343774520000","Zilverline B.V.","34377452","0","Molukkenstraat 200 E4","1098TW","Amsterdam","Hoofdvestiging",null]]}}]')
+
       OpenKVK.find_by_kvk("343774520000", :count => :first).bedrijfsnaam.should == "Zilverline B.V."
     end
   end
-  
+
   describe ".host=" do
     it "should set the host" do
       OpenKVK.host = "http://api.openkvk.nl/"
       OpenKVK.host.should == "http://api.openkvk.nl/"
     end
   end
-  
+
   describe ".options" do
     it "should return a hash with the current settings" do
       OpenKVK.host = "test host"
@@ -126,5 +126,19 @@ describe OpenKVK do
       end
     end
   end
-  
+
+  describe "integration" do
+    it "should have basic examples to work (quick integration test)" do
+      OpenKVK.host = "openkvk.nl"
+      companies = OpenKVK.search("zIlVeRlInE")
+      companies.first.bedrijfsnaam.should == "Zilverline Beheer B.V."
+      companies = OpenKVK.find("Zilverline B.V.")
+      companies.first.bedrijfsnaam.should == "Zilverline B.V."
+      companies = OpenKVK.find_by_bedrijfsnaam("Zilverline B.V.")
+      companies.first.bedrijfsnaam.should == "Zilverline B.V."
+      companies = OpenKVK.find_by_kvk("343774520000")
+      companies.first.bedrijfsnaam.should == "Zilverline B.V."
+
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,11 +14,12 @@ RSpec.configure do |config|
 end
 
 def expect_query(sql, response)
+  sql = sql+";"
   OpenKVK::API.expects(:get).with(sql).returns(response)
 end
 
 def expect_search(keywords, response)
-  OpenKVK::API.expects(:get).with(keywords, "sphinx").returns(response)
+  OpenKVK::API.expects(:get).with(keywords, "officieel").returns(response)
 end
 
 load File.expand_path('../../lib/openkvk.rb', __FILE__)


### PR DESCRIPTION
- response of the simple api is no longer just an array of kvk-numbers, now dealing with new response
- simplified find bedrijfsnaam query by changing several LIKE's to a single ILIKE
- find_by_kvk is now a special function, as KVK is now strictly a (BIG)INT. #find_by_kvk searches both the kvk and kvks columns
- closing all queries with ";", as required by the new API
- changed default limit from 1000 to 99, new API requirement
- sphinx service no longer available, now calld 'officieel'
- **I lazily added some integration tests to the spec, that actually connect to the service... may not be desired**
